### PR TITLE
Fix drop calc URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Enemy List with all drop items: https://youtu.be/H3CVpDJ8td0
 All enemies & drop items table (Sega Saturn): https://drrak.github.io/sotn/ss/  
 Enemy List with all drop items (Sega Saturn, Japan): https://youtu.be/sNycEXESgOk
 
-Drop Calculator: https://fatalis.pw/sotn/dropcalc/
+Drop Calculator: https://fatalis.github.io/sotn-dropcalc/
 
 Interactive map v0.20: https://drrak.github.io/sotn/map/?0,1,36
 


### PR DESCRIPTION
I finally moved it to a **permanent** location. The old URL will stop working soon.